### PR TITLE
Cluster numbering consistent with attribute in data table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.jar
 *.war
 *.ear
+/build/

--- a/src/de/uni_leipzig/informatik/asv/gephi/chinesewhispers/ChineseWhispersClusterer.java
+++ b/src/de/uni_leipzig/informatik/asv/gephi/chinesewhispers/ChineseWhispersClusterer.java
@@ -176,7 +176,6 @@ public class ChineseWhispersClusterer implements Clusterer, LongTask {
             int classValue = entry.getValue();
             if (! classCluster.containsKey(classValue)) {
                 ChineseWhispersClusterImpl cluster = new ChineseWhispersClusterImpl();
-                cluster.setName("Cluster for Class #"+classValue);
                 classCluster.put(classValue, cluster);
             }
             classCluster.get(classValue).addNode(entry.getKey());     
@@ -189,6 +188,11 @@ public class ChineseWhispersClusterer implements Clusterer, LongTask {
         progress.progress();
         
         result.addAll(classCluster.values());
+        
+        int i=0;
+        for (Cluster cluster : result) {
+            ((ChineseWhispersClusterImpl)cluster).setName("Cluster for Class #"+ i++);
+        }
         
         graph.readUnlockAll();
         


### PR DESCRIPTION
This pull-request changes the cluster name to actually reflect the cluster number that appears in the data table.

Gephi uses the index of the Cluster[] elements returned with getClusters() in the datatable. So, if we let this index appear in the cluster name, the cluster window and data table are coherent.

The diff looks big (don't know why), but the actual change only removes line 179 and adds lines 191-195.

Can you publish a new version, with this change, please? Our clients will update automatically.
